### PR TITLE
Enable client side caching

### DIFF
--- a/app/press/Compressor.java
+++ b/app/press/Compressor.java
@@ -14,6 +14,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -30,7 +31,7 @@ import press.io.FileIO;
 
 public abstract class Compressor extends PlayPlugin {
     static final String PRESS_SIGNATURE = "press-1.0";
-    static final String PATTERN_TEXT = "^/\\*" + PRESS_SIGNATURE + "\\|(.*?)\\*/$";
+    static final String PATTERN_TEXT = "^/\\*" + PRESS_SIGNATURE + "\\*/$";
     static final Pattern HEADER_PATTERN = Pattern.compile(PATTERN_TEXT);
 
     // File type, eg "JavaScript"
@@ -140,11 +141,8 @@ public abstract class Compressor extends PlayPlugin {
             throw new DuplicateFileException(fileType, fileName, tagName);
         }
 
-        // Check that the file exists
-        checkFileExists(fileName);
-
         // Add the file to the list of files to be compressed
-        fileInfos.put(fileName, new FileInfo(fileName, compress, null));
+        fileInfos.put(fileName, new FileInfo(fileName, compress, checkFileExists(fileName)));
 
         return getFileRequestSignature(fileName);
     }
@@ -174,8 +172,13 @@ public abstract class Compressor extends PlayPlugin {
      */
     private String getRequestKey() {
         String key = "";
-        for (String fileName : fileInfos.keySet()) {
-            key += fileName;
+        for (Entry<String, FileInfo> entry : fileInfos.entrySet()) {
+            key += entry.getKey();
+            // If we use the 'Change' caching strategy, make the modified timestamp
+            // of each file part of the key.
+            if(PluginConfig.cache.equals(CachingStrategy.Change)) {
+                key += entry.getValue().getLastModified();
+            }
         }
 
         // Get a hash of the url to keep it short
@@ -290,7 +293,14 @@ public abstract class Compressor extends PlayPlugin {
 
     protected static CompressedFile getCompressedFile(FileCompressor compressor,
             List<FileInfo> componentFiles, String compressedDir, String extension) {
-        String joinedFileNames = JavaExtensions.join(FileInfo.getFileNames(componentFiles), "");
+
+        String joinedFileNames = null;
+        if(PluginConfig.cache.equals(CachingStrategy.Change)) {
+            joinedFileNames = JavaExtensions.join(FileInfo.getFileNamesAndModifiedTimestamps(componentFiles), "");
+        } else {
+            joinedFileNames = JavaExtensions.join(FileInfo.getFileNames(componentFiles), "");
+        }
+
         String fileName = Crypto.passwordHash(joinedFileNames);
         fileName = FileIO.lettersOnly(fileName);
         String filePath = compressedDir + fileName + extension;
@@ -328,11 +338,8 @@ public abstract class Compressor extends PlayPlugin {
         }
 
         try {
-            // Add the last modified dates of each component file to the
-            // start of the compressed file so that we can later check if
-            // any of them have changed.
-            String lastModifiedDates = createFileHeader(componentFiles);
-            writer.append(lastModifiedDates);
+
+            writer.append(createFileHeader());
 
             for (FileInfo componentFile : componentFiles) {
                 compress(compressor, componentFile, writer);
@@ -359,114 +366,30 @@ public abstract class Compressor extends PlayPlugin {
             return false;
         }
 
-        if (PluginConfig.cache.equals(CachingStrategy.Always)) {
-            return true;
-        }
-
-        boolean changed = haveComponentFilesChanged(componentFiles, file);
-        if (changed) {
-            PressLogger.trace("Component %s files have changed", extension);
-        } else {
-            PressLogger.trace("Component %s files have not changed", extension);
-        }
-
-        return !changed;
+        // If the caching strategy is Change, we can still use the cache, because we
+        // included the modification timestamp in the key name, so same key means
+        // that it is not modified.
+        return true;
     }
 
-    private static boolean haveComponentFilesChanged(List<FileInfo> componentFiles,
-            CompressedFile file) {
-
-        // Check if the file exists
-        if (!file.exists()) {
-            return true;
-        }
-
-        // Check if the file has a compression header
-        String header = extractHeaderContent(file);
-        if (header == null) {
-            return true;
-        }
-
-        // Check if the number of files has changed
-        String[] lastModifieds = header.split(":");
-        if (lastModifieds.length != componentFiles.size()) {
-            return true;
-        }
-
-        try {
-            // Check each of the stored last modified dates against the file's
-            // current last modified date
-            for (int i = 0; i < componentFiles.size(); i++) {
-                FileInfo fileInfo = componentFiles.get(i);
-
-                // Check if the file was compressed and is now uncompressed,
-                // or vice versa
-                char compress = fileInfo.compress ? 'c' : 'u';
-                if (lastModifieds[i].charAt(0) != compress) {
-                    return true;
-                }
-
-                // Check the timestamp
-                String lastMod = lastModifieds[i].substring(1);
-                long lastModified = Long.parseLong(lastMod);
-                if (fileInfo.file.lastModified() != lastModified) {
-                    return true;
-                }
-            }
-        } catch (Exception e) {
-            // If there's any sort of problem reading the header, we can just
-            // overwrite the file
-            return true;
-        }
-
-        return false;
+    public static String createFileHeader() {
+        return "/*" + PRESS_SIGNATURE + "*/\n";
     }
 
-    /**
-     * <pre>
-     * The file header consists of
-     * - An opening comment
-     * - A signature
-     * - A '|' character used as a separator
-     * - A ':' separated list of
-     *   o the character 'c' or 'u', indicating whether the file is compressed
-     *   o a unix timestamp
-     * - A closing comment
-     * 
-     * eg
-     * press-1.0|c12323123:u1231212:c1312312:c1312423
-     * </pre>
-     * 
-     */
-    public static String createFileHeader(List<FileInfo> componentFiles) {
-        List<String> timestamps = new ArrayList<String>(componentFiles.size());
-
-        for (int i = 0; i < componentFiles.size(); i++) {
-            FileInfo fileInfo = componentFiles.get(i);
-            String lastMod = Long.toString(fileInfo.file.lastModified());
-            char compress = fileInfo.compress ? 'c' : 'u';
-            timestamps.add(compress + lastMod);
-        }
-
-        return "/*" + PRESS_SIGNATURE + "|" + JavaExtensions.join(timestamps, ":") + "*/\n";
-    }
-
-    public static String extractHeaderContent(CompressedFile file) {
+    public static boolean hasPressHeader(CompressedFile file) {
         try {
             if (!file.exists()) {
-                return null;
-
+                return false;
             }
             BufferedReader reader = new BufferedReader(new InputStreamReader(file.inputStream()));
             String firstLine = reader.readLine();
             Matcher matcher = HEADER_PATTERN.matcher(firstLine);
             if (matcher.matches()) {
-                return matcher.group(1);
+                return true;
             }
-            return null;
-
+            return false;
         } catch (IOException e) {
-            throw new UnexpectedException(e);
+            return false;
         }
     }
 
@@ -544,6 +467,10 @@ public abstract class Compressor extends PlayPlugin {
             this.file = file == null ? null : file.getRealFile();
         }
 
+        public long getLastModified() {
+            return file.lastModified();
+        }
+
         public static Collection<String> getFileNames(List<FileInfo> list) {
             Collection<String> fileNames = new ArrayList<String>(list.size());
             for (FileInfo fileInfo : list) {
@@ -551,6 +478,15 @@ public abstract class Compressor extends PlayPlugin {
             }
 
             return fileNames;
+        }
+
+        public static Collection<String> getFileNamesAndModifiedTimestamps(List<FileInfo> list) {
+            Collection<String> fileNamesAndModifiedTimestamps = new ArrayList<String>(list.size());
+            for(FileInfo fileInfo : list) {
+                fileNamesAndModifiedTimestamps.add(fileInfo.fileName + fileInfo.getLastModified());
+            }
+
+            return fileNamesAndModifiedTimestamps;
         }
     }
 }

--- a/app/press/PluginConfig.java
+++ b/app/press/PluginConfig.java
@@ -12,8 +12,7 @@ public class PluginConfig {
         public static final boolean enabled = (Play.mode == Mode.PROD);
 
         // The caching strategy
-        public static final CachingStrategy cache = (Play.mode == Mode.DEV) ? CachingStrategy.Change
-                : CachingStrategy.Always;
+        public static final CachingStrategy cache = CachingStrategy.Change;
 
         // Whether the cache can be cleared through the web interface
         // Default is to be available in dev only

--- a/app/press/io/PressFileFilter.java
+++ b/app/press/io/PressFileFilter.java
@@ -22,6 +22,6 @@ public class PressFileFilter implements FileFilter {
         // compressed file
         VirtualFile virt = VirtualFile.open(file);
         CompressedFile compressedFile = CompressedFile.create(virt.relativePath());
-        return compressedFile.exists() && Compressor.extractHeaderContent(compressedFile) != null;
+        return compressedFile.exists() && Compressor.hasPressHeader(compressedFile);
     }
 }

--- a/documentation/manual/home.textile
+++ b/documentation/manual/home.textile
@@ -113,15 +113,20 @@ h2. <a>Tips</a>
 * Don't use press from within a 404.html or 500.html template. When invoking an error template Play changes the request object causing press to fail.
 
 
-h2. <a name="caching">Caching</a>
+h2. <a name="caching">Server Caching</a>
 
-When a compressed file is generated for a given set of input files, it is stored on disk in a configurable location. The next time the same set of files in the same order is requested, the file is retrieved from the cache.
+When a compressed file is generated for a given set of input files, it is stored on disk in a configurable location. The next time the same set of files in the same order is requested, the file is retrieved from the cache. This is server side caching.
 
-press uses different caching mechanisms depending on whether Play is in dev or production mode. These can be overridden in "Configuration":#configuration. 
-* In dev mode, __press__ by default uses the caching strategy **Change**: __press__ will detect changes to the JS and CSS files real time. Simply save and refresh the page.
-* In production mode, __press__ by default uses the caching strategy **Always**: __press__ will not auto-detect changes. The cache is cleared each time the server is restarted.
-* There is a third caching strategy that can be configured called **Never**, in which __press__ will not use the cache. Compression will be performed for every page request. This mode obviously puts a high load on the server and is only recommended if one of the above strategies cannot be used for some reason.
+__press__ has three different caching mechanisms, of which you can choose one. 
+* The most useful caching strategy is **Change**: __press__ will detect changes to the JS and CSS files real time. Simply save and refresh the page. This caching strategy is also the only one that sets the proper headers for "Client Caching":#clientcaching. This strategy is recommended in all cases. 
+* Caching strategy **Always**: __press__ will not auto-detect changes. The cache is cleared each time the server is restarted. With this strategy, client side caching is disabled.
+* Caching strategy **Never**: __press__ will not use the cache. Compression will be performed for every page request. This mode obviously puts a high load on the server and is only recommended if one of the above strategies cannot be used for some reason. Also, client side caching is disabled.
 
+h2. <a name="clientcaching">Client Side Caching</a>
+
+If you use the **Change** caching strategy, __press__ will generate a unique key for the files that you compress, that contains the last modified timestamp of these files. Now when the compressed file is served, it is send with an HTTP Header to tell the browser that the file does not expire, and can be cached. When you modify the source file, the key changes automatically, so only then will a browser do a new request.
+
+With the **Always** or **Never** caching strategies, the file modification time is not part of the key, and no cache-enabling header is sent. 
 
 h2. <a name="inmem">In-Memory storage</a>
 
@@ -151,16 +156,16 @@ h3. __press.cache__
 
 The caching strategy to use. See "Caching":#caching.
 
-**press.cache=Always**
-   The cache will always be used, regardless of whether the component files have changed. The cache will be cleared when the server is restarted - this mode is recommended for a production environment.
-
 **press.cache=Change**
-   The compressed file will be regenerated when the last modified date of one of the source js or css files is detected to have changed - recommended for a dev environment.
+   The compressed file will be regenerated when the last modified date of one of the source js or css files is detected to have changed, and client side caching is maximized - recommended for all purposes.
+   
+**press.cache=Always**
+   The server cache will always be used, regardless of whether the component files have changed. The server cache will be cleared when the server is restarted. Client side caching is disabled. This mode is not recommended.
 
 **press.cache=Never**
-   The cache will not be used: the js and css files will be compressed on every request
+   The cache will not be used: the js and css files will be compressed on every request, and client side caching is disabled.
 
-By default, when play is in dev mode the caching strategy is **Change**, and in production it is **Always**.
+By default, the caching strategy is **Change**.
 
 
 h3. __press.cache.clearEnabled__


### PR DESCRIPTION
Hi Dirk,

this is a rather large change proposal. It's purpose is to allow client side caching. 

Regular CSS and JS files as served by Play, have an Etag, and Play checks both the Etag and the If-Modified-Since headers that clients send. So the second time that an unmodified (as by the modification timestamp) file is requested, Play returns a 304 Not Modified header, and a blank body, saving a lot of bandwidth and time.

The press plugin, excellent as it is, does not use ETags, nor does it look at the If-Modified-Since header. It also does not send an Expires header, and the Cache-Control header says no-cache (that's a Play default). So not only are clients requested to not cache the compressed file, but Press also keeps sending the same version over and over, for every request. This way, much of the gain that you get from press (smaller files) is immediately lost, since the smaller files are downloaded for every request, while regular css and js files are not.

press generates a key for every set of files that need to be compressed. This commit changes the key generation, so that the file modification time of all those files is a part of the key. Now, we can serve the compressed files with an Expires-in-a-year-cache-as-long-as-you-want header, because if we change one of the files, the key changes automatically, so the browser will request the new version! 

This also makes server side caching somewhat less awkward (storing the modification dates in the first line of the cached file is quite awkward ;)), since the modification date is encoded in the key, so if we don't have a cached file on the server with that key, we can safely assume that one of the source files has changed, and a new compressed file must be created. 

Using this method means that caching strategy 'Change' is the only sane one left.

So, what this commit changes is the roughtly following:
- Encode the modified time of all the files in the key
- Don't store the modified time in the first line of the compressed file
- Serve the compressed files with a Expires header in the far future
- Updated documentation
  for more details, see the code!

I have tried to stick to your coding and documentation style! It has been tested only a little. 

I hope you can pull this commit, or alternatively code something like it, since I do believe that without proper support for client side caching, the press module is almost useless, which is sad because it's great otherwise!

Erik
