### PR TITLE
Press over https breaks IE privacy policy

### DIFF
--- a/app/controllers/press/Press.java
+++ b/app/controllers/press/Press.java
@@ -75,6 +75,7 @@ public class Press extends Controller {
             // Cache for a year
             response.setHeader("Cache-Control", "max-age=" + 31536000);
             response.setHeader("Expires", httpDateTimeFormatter.print(new DateTime().plusYears(1)));
+            response.setHeader("P3P", "CP=\"IDC DSP CURa ADMa DEVa TAIa OUR BUS IND UNI COM NAV INT\"");
         }
 
         renderBinary(inputStream, compressedFile.name());


### PR DESCRIPTION
When you use IE over https, as press does not set the P3P header, Internet Explorer does not render the CSS nor the JS files. This pull request is to resolve that.
Now we set the P3P headers, so IE stops complaining.
