### PR TITLE
Fix issue with bad expiry time

### DIFF
--- a/app/press/io/InMemoryCompressedFile.java
+++ b/app/press/io/InMemoryCompressedFile.java
@@ -23,7 +23,7 @@ public class InMemoryCompressedFile extends CompressedFile {
     private Writer writer;
     private ByteArrayOutputStream outputStream;
     private byte[] bytes;
-    private static final String A_VERY_LONG_TIME = "3650d";
+    private static final String A_VERY_LONG_TIME = "30d";
 
     public InMemoryCompressedFile(String fileKey) {
         super(fileKey);


### PR DESCRIPTION
memcache doesn't support expiry dates longer than 30 days. The old value (3650d) caused memcache to nuke entries, so it could not return them.
