### PR TITLE
No longer throwing duplicate file exception

### DIFF
--- a/app/press/RequestHandler.java
+++ b/app/press/RequestHandler.java
@@ -7,6 +7,8 @@ import play.mvc.Router;
 import play.vfs.VirtualFile;
 import press.io.FileIO;
 
+import play.Logger;
+
 public abstract class RequestHandler {
     Map<String, Boolean> files = new HashMap<String, Boolean>();
 
@@ -50,10 +52,10 @@ public abstract class RequestHandler {
             files.put(fileName, true);
             return;
         }
-
-        SourceFileManager srcManager = getSourceManager();
-        throw new DuplicateFileException(srcManager.getFileType(), fileName,
-                srcManager.getTagName());
+        Logger.info("Ignoring duplicate file: " + fileName);
+        //SourceFileManager srcManager = getSourceManager();
+        //throw new DuplicateFileException(srcManager.getFileType(), fileName,
+        //        srcManager.getTagName());
     }
 
     protected static String getCompressedUrl(String action, String requestKey) {


### PR DESCRIPTION
I have had plenty of problems with duplicate file exceptions when I compress both javascript and css on the same page.
Compressing them separately works fine but not both together.

I really don't see a reason why this should throw an exception at all since it shouldn't prevent the application from starting when the file can simply be ignored and logged.
